### PR TITLE
Fixed Bug when IPv6 is enabled

### DIFF
--- a/automate_nginx.sh
+++ b/automate_nginx.sh
@@ -43,7 +43,7 @@ server {
 }
 EOF
 
-myip=`hostname -i`
+myip=`hostname -i | awk '{print $1}'`
 sed -i "s/x.x.x.x/$myip/" /etc/nginx/nginx.conf
 
 


### PR DESCRIPTION
When IPv6 is enabled, `hostname -i` returns two values. The first value represents the IPv4 value and the second one the IPv6 value. Output looks similar to the following:
```sh
$ hostname -i
<IPv4 address> <IPv6 address>
```
This change makes sure that only the first entry is grabbed. (`hostname -i | awk '{print $1}'`)

Without the change, the installation of the VM extension fails with the following error:
```sh
[stderr]
nginx: [emerg] the invalid "<IPv6 address>" parameter in /etc/nginx/nginx.conf:92
nginx: configuration file /etc/nginx/nginx.conf test failed
```

